### PR TITLE
update version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,7 @@ jobs:
   build:
     needs: release
     runs-on: ubuntu-latest
+    if: always()
     container:
       image: alpine
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,6 @@ jobs:
   build:
     needs: release
     runs-on: ubuntu-latest
-    if: always()
     container:
       image: alpine
     strategy:

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -1,10 +1,10 @@
 #!/bin/sh -eux
 
-readonly FISH_VERSION ARTIFACTS_DIR
-
 FISH_VERSION=3.3.1
 
 ARTIFACTS_DIR="$(realpath ./artifacts)"
+
+readonly FISH_VERSION ARTIFACTS_DIR
 
 apk add cmake g++ gcc make musl-dev \
         ncurses-dev ncurses-static

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -1,6 +1,5 @@
 #!/bin/sh -eux
 
-# FISH_VERSION=3.1.2
 FISH_VERSION=3.2.2
 
 ARTIFACTS_DIR="$(realpath ./artifacts)"

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -13,8 +13,8 @@ apk add cmake g++ gcc make musl-dev \
 ln -f /usr/lib/libncursesw.a /usr/lib/libcurses.a
 
 cd /tmp
-wget -O- "https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz" \
-     | tar zxvf -
+wget -O- "https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.xz" \
+     | tar Jxvf -
 cd "fish-${FISH_VERSION}"
 cmake -DCMAKE_INSTALL_PREFIX="${ARTIFACTS_DIR}/fish-${FISH_VERSION}" \
       -DCMAKE_C_FLAGS="-Ofast" -DCMAKE_CXX_FLAGS="-Ofast" \

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -eux
 
-FISH_VERSION=3.3.1
+# FISH_VERSION=3.1.2
+FISH_VERSION=3.2.0
 
 ARTIFACTS_DIR="$(realpath ./artifacts)"
 

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
-# FISH_VERSION=3.2.2
-FISH_VERSION=3.3.0
+# FISH_VERSION=3.1.2
+FISH_VERSION=3.2.2
 
 ARTIFACTS_DIR="$(realpath ./artifacts)"
 

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
-# FISH_VERSION=3.1.2
-FISH_VERSION=3.2.2
+# FISH_VERSION=3.2.2
+FISH_VERSION=3.3.0
 
 ARTIFACTS_DIR="$(realpath ./artifacts)"
 

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -1,18 +1,25 @@
 #!/bin/sh -eux
 
-FISH_VERSION=3.1.2
+readonly FISH_VERSION ARTIFACTS_DIR
 
-ARTIFACTS_DIR=$(realpath $(dirname ${0})/artifacts)
+FISH_VERSION=3.3.1
 
-apk add gcc g++ make cmake musl-dev ncurses-dev ncurses-static
+ARTIFACTS_DIR="$(realpath ./artifacts)"
+
+apk add cmake g++ gcc make musl-dev \
+        ncurses-dev ncurses-static
+
 
 ln -f /usr/lib/libncursesw.a /usr/lib/libcurses.a
 
 cd /tmp
-wget https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz -O - | tar zxvf -
-cd fish-${FISH_VERSION}
-cmake -DCMAKE_INSTALL_PREFIX=${ARTIFACTS_DIR}/fish-${FISH_VERSION} -DCMAKE_C_FLAGS="-Ofast" -DCMAKE_CXX_FLAGS="-Ofast" -DCMAKE_EXE_LINKER_FLAGS="-static -no-pie -s" .
+wget -O- "https://github.com/fish-shell/fish-shell/releases/download/${FISH_VERSION}/fish-${FISH_VERSION}.tar.gz" \
+     | tar zxvf -
+cd "fish-${FISH_VERSION}"
+cmake -DCMAKE_INSTALL_PREFIX="${ARTIFACTS_DIR}/fish-${FISH_VERSION}" \
+      -DCMAKE_C_FLAGS="-Ofast" -DCMAKE_CXX_FLAGS="-Ofast" \
+      -DCMAKE_EXE_LINKER_FLAGS="-static -no-pie -s" .
 make -j8 install
 
-cd ${ARTIFACTS_DIR}
-tar zcvf fish-${FISH_VERSION}.tar.gz fish-${FISH_VERSION}
+cd "${ARTIFACTS_DIR}"
+tar zcvf "fish-${FISH_VERSION}.tar.gz" "fish-${FISH_VERSION}"

--- a/fish/build.sh
+++ b/fish/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
 
 # FISH_VERSION=3.1.2
-FISH_VERSION=3.2.0
+FISH_VERSION=3.2.2
 
 ARTIFACTS_DIR="$(realpath ./artifacts)"
 

--- a/nano/build.sh
+++ b/nano/build.sh
@@ -1,11 +1,11 @@
 #!/bin/sh -eux
 
-readonly FILE_VERSION NANO_VERSION ARTIFACTS_DIR
-
 FILE_VERSION=5.40
 NANO_VERSION=5.8
 
 ARTIFACTS_DIR="$(realpath ./artifacts)"
+
+readonly FILE_VERSION NANO_VERSION ARTIFACTS_DIR
 
 apk add gcc groff linux-headers make musl-dev \
         ncurses-dev ncurses-static zlib-dev zlib-static

--- a/nano/build.sh
+++ b/nano/build.sh
@@ -1,23 +1,27 @@
 #!/bin/sh -eux
 
-FILE_VERSION=5.39
-NANO_VERSION=5.3
+readonly FILE_VERSION NANO_VERSION ARTIFACTS_DIR
 
-ARTIFACTS_DIR=$(realpath $(dirname ${0})/artifacts)
+FILE_VERSION=5.40
+NANO_VERSION=5.8
 
-apk add gcc make groff linux-headers musl-dev ncurses-dev ncurses-static zlib-dev zlib-static
+ARTIFACTS_DIR="$(realpath ./artifacts)"
+
+apk add gcc groff linux-headers make musl-dev \
+        ncurses-dev ncurses-static zlib-dev zlib-static
 
 cd /tmp
-wget http://ftp.astron.com/pub/file/file-${FILE_VERSION}.tar.gz -O - | tar zxvf -
-cd file-${FILE_VERSION}
+wget "http://ftp.astron.com/pub/file/file-${FILE_VERSION}.tar.gz" -O - | tar zxvf -
+cd "file-${FILE_VERSION}"
 ./configure --prefix=/usr CFLAGS="-Ofast" --enable-static
 make -j8 install
 
 cd /tmp
-wget https://www.nano-editor.org/dist/v${NANO_VERSION%%.*}/nano-${NANO_VERSION}.tar.gz -O - | tar zxvf -
-cd nano-${NANO_VERSION}
-./configure --prefix=${ARTIFACTS_DIR}/nano-${NANO_VERSION} CFLAGS="-Ofast" LDFLAGS="-static -no-pie -s" LIBS="-lz"
+wget -O- "https://www.nano-editor.org/dist/v${NANO_VERSION%%.*}/nano-${NANO_VERSION}.tar.gz" \
+     | tar zxvf -
+cd "nano-${NANO_VERSION}"
+./configure --prefix="${ARTIFACTS_DIR}/nano-${NANO_VERSION}" CFLAGS="-Ofast" LDFLAGS="-static -no-pie -s" LIBS="-lz"
 make -j8 install
 
-cd ${ARTIFACTS_DIR}
-tar zcvf nano-${NANO_VERSION}.tar.gz nano-${NANO_VERSION}
+cd "${ARTIFACTS_DIR}"
+tar zcvf "nano-${NANO_VERSION}.tar.gz" "nano-${NANO_VERSION}"

--- a/nano/build.sh
+++ b/nano/build.sh
@@ -11,16 +11,17 @@ apk add gcc groff linux-headers make musl-dev \
         ncurses-dev ncurses-static zlib-dev zlib-static
 
 cd /tmp
-wget "http://ftp.astron.com/pub/file/file-${FILE_VERSION}.tar.gz" -O - | tar zxvf -
+wget -O- "http://ftp.astron.com/pub/file/file-${FILE_VERSION}.tar.gz" | tar zxvf -
 cd "file-${FILE_VERSION}"
-./configure --prefix=/usr CFLAGS="-Ofast" --enable-static
+./configure --enable-static --prefix=/usr CFLAGS="-Ofast"
 make -j8 install
 
 cd /tmp
 wget -O- "https://www.nano-editor.org/dist/v${NANO_VERSION%%.*}/nano-${NANO_VERSION}.tar.gz" \
      | tar zxvf -
 cd "nano-${NANO_VERSION}"
-./configure --prefix="${ARTIFACTS_DIR}/nano-${NANO_VERSION}" CFLAGS="-Ofast" LDFLAGS="-static -no-pie -s" LIBS="-lz"
+./configure --prefix="${ARTIFACTS_DIR}/nano-${NANO_VERSION}" \
+            CFLAGS="-Ofast" LDFLAGS="-static -no-pie -s" LIBS="-lz"
 make -j8 install
 
 cd "${ARTIFACTS_DIR}"


### PR DESCRIPTION
バージョンを上げました。`fish>=3.3.0`から`-static`が効かなくなっている模様です。nanoはlatestのものです。
```diff
-FISH_VERSION=3.1.2
+FISH_VERSION=3.2.2

-FILE_VERSION=5.39
-NANO_VERSION=5.3
+FILE_VERSION=5.40
+NANO_VERSION=5.8
```
また[shellcheck](https://github.com/koalaman/shellcheck)のエラーを修正し、長いコマンドに改行を入れました。
